### PR TITLE
等级墙, 用户头像跳转B站空间, 抽选中断

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
 
             <form class="form-inline col-12">
 
-                <div class="input-group input-group-lg my-3 mx-auto col-8">
+                <div class="input-group input-group-lg my-3 mx-auto col-6">
                     <div class="input-group-prepend">
                         <label class="input-group-text" for="dynamic_link">动态地址</label>
                     </div>
@@ -47,12 +47,20 @@
                            placeholder="https://t.bilibili.com/xxx"/>
                 </div>
 
-                <div class="input-group  input-group-lg  my-3 mx-auto col-4">
+                <div class="input-group  input-group-lg  my-3 mx-auto col-3">
                     <div class="input-group-prepend">
                         <label class="input-group-text" for="winner-number">抽选人数</label>
                     </div>
                     <input class="form-control " type="number" id="winner-number" name="winner-number"
                            value="1" min="1"/>
+                </div>
+
+                <div class="input-group  input-group-lg  my-3 mx-auto col-3">
+                    <div class="input-group-prepend">
+                        <label class="input-group-text" for="level-filter">等级墙</label>
+                    </div>
+                    <input class="form-control " type="number" id="level-filter" name="level-filter" value="0" min="0"
+                        max="6"/>
                 </div>
 
             </form>

--- a/public/js/base.js
+++ b/public/js/base.js
@@ -1,5 +1,7 @@
 //全局用户列表
 const USER_LIST = [];
+//全局记录被中断标志，用于判定抽选过程被中断
+let IS_INTERRUPED = false;
 
 
 
@@ -13,5 +15,3 @@ const USER_LIST = [];
 function getRandomInt(min, max){
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
-
-

--- a/public/js/get-user.js
+++ b/public/js/get-user.js
@@ -6,10 +6,20 @@ const BILIBILI_URL = 'bilibili.com';
 $(function () {
 
     $('.get-button').on('click', getRepostUser);
+    //监听等级墙变化
+    $('#level-filter').on('change', resetLevelFilter);
 
 
 
 });
+
+/**
+ * 等级墙变更后禁用开始抽选按钮
+ */
+function resetLevelFilter() {
+    //禁用开始抽选按钮
+    $('.start-button').attr('disabled', true);
+}
 
 /**
  * 获取用户列表
@@ -81,6 +91,8 @@ function getRepostUser(event) {
  */
 function sendRequest(dynamicId) {
 
+    //将被中断标记置为真
+    IS_INTERRUPED = true
     let $toast = $('.toast1');
     //列表
     let $userListElement = $('.user-list');
@@ -90,8 +102,12 @@ function sendRequest(dynamicId) {
     //清空数据列表
     USER_LIST.length = 0;
 
+    //获取等级墙
+    let levelFilter = $('#level-filter').val();
+    //关闭抽选进行中的Toast
+    $('.toast2').toast('hide');
     //注销按钮
-    $('#get-button').attr('disabled', true);
+    $('.get-button').attr('disabled', true);
     //显示模态加载窗口
     $('.modal').modal('show');
 
@@ -111,21 +127,27 @@ function sendRequest(dynamicId) {
             //遍历每个元素
             data.forEach(function (user) {
 
-                //保存到全局列表
-                USER_LIST.push(user);
+                // 等级过滤
+                if (user.level >= levelFilter) {
 
-                //创建插入元素到页面
-                let newElement = `
+                    //保存到全局列表
+                    USER_LIST.push(user);
+
+                    //创建插入元素到页面
+                    let newElement = `
 <div class="border col-3 m-2 rounded">
+    <a href="https://space.bilibili.com/${user.uid}" id="user-link" target="_blank">
     <img class="img-fluid rounded-circle m-1" src="${user.avatar}" alt="${user.name}" referrerPolicy="no-referrer"/>
     <span class="m-1 name small">
         ${user.name}
     </span>
+    </a>
     <span class="badge ${getBgColorClass(user.level - 1)} m-1">
         Lv ${user.level}
     </span>
 </div>`;
-                $userListElement.append(newElement);
+                    $userListElement.append(newElement);
+                }
             });
 
             // 激活按钮
@@ -194,5 +216,3 @@ function getBgColorClass(index) {
     return BG_CLASSES[index];
 
 }
-
-

--- a/public/js/start-game.js
+++ b/public/js/start-game.js
@@ -29,7 +29,8 @@ $(function () {
  */
 function startGame() {
 
-
+    // 开始新的抽选, 中断结束
+    IS_INTERRUPED = false
     //如果剩余人数大于要抽选的人数, 继续抽选
     if (USER_LIST.length > winnerNumber) {
 
@@ -44,13 +45,14 @@ function startGame() {
             USER_LIST.splice(randomIndex, 1);
             //更新剩余数量显示
             $('.toast2 .toast-body').html("剩余: " + USER_LIST.length);
-            //定时下个循环
-            setTimeout(startGame, removeSpeed());
+            //定时下个循环, 发生中断后中止循环
+            if (!IS_INTERRUPED) {
+                setTimeout(startGame, removeSpeed());
+            }
         });
 
-
-    } else {
-
+    //没有发生中断才能正常结束
+    } else if (!IS_INTERRUPED) {
         endGame();
     }
 
@@ -91,4 +93,3 @@ function removeSpeed() {
 
 
 }
-

--- a/public/style.css
+++ b/public/style.css
@@ -16,3 +16,18 @@
     display: inline-block;
     vertical-align: middle;
 }
+
+#user-link {
+    color: #6d757a;
+    text-decoration: none;
+}
+
+#user-link:hover {
+    color: #6d757a;
+    text-decoration: none;
+}
+
+#user-link:visited {
+    color: #6d757a;
+    text-decoration: none;
+}


### PR DESCRIPTION
- **新功能**
 1. 等级墙, 设定等级墙以过滤等级低于所设等级的用户, 默认为最低0级(不过滤), 最高为6级(只允许6级大佬), 修改等级墙后需要重新获取用户
 2. 点击用户头像或用户名, 即可在新标签页打开B站用户个人空间
- **错误修复**
**描述**: 若在抽选过程中点击"获取转发用户"按钮, 抽选不会停止, 继续循环setTimeout()淘汰用户, 必须刷新重载页面
**解决**: 在base.js中新增全局变量IS_INTERRUPED作为中断信号量, 初始值false; 当点击"获取转发用户"按钮时, 设为true, 条件判断阻止抽选过程的setTimeout(); 直到再次点击"开始抽选"按钮, 重新设置为false, 允许正常setTimeout()

> 前端萌新表示在Github上总算找到一个勉强能看得懂的项目了, 还是社长的555555