### PR TITLE
评论列表处理逻辑

### DIFF
--- a/vue/src/components/content/MyList.vue
+++ b/vue/src/components/content/MyList.vue
@@ -115,7 +115,7 @@ function on_click_is_my_fans(user) {
                                     {{ user.user_name }}
                                 </a>
                             </div>
-                            <div v-show="user.date || user.level || user.vip_description" class="smaller my-2">
+                            <div v-show="user.date || user.level || user.vip_description || user.relation_comment" class="smaller my-2">
                                 <span v-show="user.date"
                                     class="bg-secondary text-bg-secondary rounded-1 me-1 p-1"><font-awesome-icon
                                         :icon="faClock" class="me-1" /> {{ user.date }}</span>
@@ -125,6 +125,15 @@ function on_click_is_my_fans(user) {
                                         'Lv' + user.level : '' }}</span>
                                 <span v-show="user.vip_description" class="bg-miku text-bg-miku rounded-1 ms-1 p-1">{{
                                     user.vip_description }}</span>
+                                <span v-show="user.relation_comment" class="bg-miku text-bg-miku rounded-1 ms-1 p-1" style="background-color: #8f6e9b !important;">{{
+                                    Object.keys(user.relation_comment).length - 1 }}个相同评论</span>
+                                <span v-show="user.relation_comment" class="bg-miku text-bg-miku rounded-1 ms-1 p-1" style="background-color: #e27520 !important;">
+                                    {{
+                                    user.relation_comment_is_slef === null ? '未计算' :
+                                        user.relation_comment_is_slef ? '原创评论' :
+                                            '复制评论'
+                                  }}
+                                </span>
                             </div>
                             <div v-show="user.content" class="small text-muted one-line-text" :title="user.content">
 

--- a/vue/src/components/content/MyListContainer.vue
+++ b/vue/src/components/content/MyListContainer.vue
@@ -6,7 +6,7 @@ import { computed, onMounted, reactive, ref, inject, watch, watchEffect } from "
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faClock, faCrown, faFilter, faTriangleExclamation } from "@fortawesome/free-solid-svg-icons";
 import VueDatePicker from '@vuepic/vue-datepicker';
-import { clear_object, format_date_to_string, parse_date_string } from "@/utils/utils";
+import {clear_object, format_date_to_string, parse_date_string, parse_date_string_to_timestamp} from "@/utils/utils";
 
 import { INJECTION_KEY } from '@/constants/injection-key';
 import { API_ENDPOINT } from "@/constants/constants";
@@ -49,7 +49,7 @@ const ARRAY_LEVEL_OPTION = [
  * 过滤器
  */
 const number_people_selected_filter = ref(1)
-const repeat_comment_filter = ref(true)
+const repeat_comment_filter = ref('earliest_long_identical')
 const min_level_filter = ref('')
 const vip_filter = ref(false)
 const content_filter = ref('')
@@ -74,63 +74,109 @@ const result_winner_list = reactive([])
 //     return enable_comment_list.value && !enable_like_list.value && !enable_forward_list.value
 // })
 
+// 为 "earliest_long_identical" 过滤器预计算每种处理后内容的最早日期
+const earliestDatesByContent = {};
+function make_comment_dict(){
+    for (const user of user_list) {
+      let processedContent = user.content;
+      if (content_filter.value !== '') {
+        // 假设 content_filter.value 是一个普通字符串，需要全局替换
+        // 为了安全起见，如果 content_filter.value 可能包含正则特殊字符，需要先转义
+        processedContent = user.content.replace(content_filter, '');
+      }
+      const userDateTimestamp = parse_date_string_to_timestamp(user.date); // 确保返回可比较的值，如时间戳
+
+      if (!earliestDatesByContent[processedContent]) {
+        earliestDatesByContent[processedContent]={}
+      }
+      earliestDatesByContent[processedContent][userDateTimestamp] = user
+      }
+}
+
 const filtered_list = computed(() => {
+  if (earliestDatesByContent){
+    make_comment_dict()
+  }
 
 
-    const id_set = new Set();
+  const id_set = new Set(); // 用于过滤重复用户ID
 
+  return user_list.filter(user => {
+    let result = true;
 
-    return user_list.filter(user => {
+    // 过滤重复评论用户（基于 user.id）
+    // 注意："last_user_comment" 根据当前逻辑是保留用户首次出现的评论
+    if (["last_user_comment", "earliest_long_identical"].includes(repeat_comment_filter.value)) {
+      if (id_set.has(user.id)) {
+        // 如果 "last_user_comment" 真的是要最后一个，这里的逻辑需要完全重写，
+        // 可能需要对 user_list 按用户和时间排序预处理。
+        // 当前逻辑是：如果用户ID已存在，则过滤掉（即保留第一个出现的）
+        result = false;
+      } else {
+        id_set.add(user.id);
+      }
+    }
 
-        let result = true;
+    // 只有是评论列表的时候 才启用的过滤器
+    if (enable_comment_list.value) {
+      // 用户等级过滤
+      if (result && min_level_filter.value !== '') {
+        result = user.level >= Number(min_level_filter.value); // 确保比较的是数字
+      }
 
-        //过滤重复评论用户
-        if (repeat_comment_filter.value === true) {
+      // VIP过滤
+      if (result && vip_filter.value === true) {
+        result = user.vip && user.vip !== ''; // 确保 user.vip 存在且不为空
+      }
 
-            //使用set 和id属性 来过滤掉数组里重复的用户
-            if (id_set.has(user.id)) {
-                result = false;
-            } else {
-                id_set.add(user.id);
-            }
+      // 评论内容过滤 (包含关键词)
+      if (result && content_filter.value !== '') {
+        result = user.content.includes(content_filter.value);
+      }
+
+      // 最早评论时间过滤
+      if (result && date_comment_filter_start.value) {
+        result = parse_date_string(user.date) >= parse_date_string(date_comment_filter_start.value);
+      }
+
+      // 最晚评论时间过滤
+      if (result && date_comment_filter_end.value) {
+        result = parse_date_string(user.date) <= parse_date_string(date_comment_filter_end.value);
+      }
+
+      // 内容相同但时间最早的评论过滤器 (earliest_long_identical)
+      // 这个过滤器依赖于上面已经通过 id_set 的用户。
+      // 如果一个用户有多条内容相同的评论，并且这条是该用户最早的，但不是所有用户中最早的，行为需要明确。
+      // 当前 id_set 的逻辑会先按用户去重（保留第一个），然后再应用这个。
+      // 如果 earliest_long_identical 应该独立于用户去重，id_set 的条件需要调整。
+      // 假设这里的目的是：在通过了前面的用户去重（如果开启了）之后，再应用此规则。
+      if (result && repeat_comment_filter.value === 'earliest_long_identical') {
+        let processedContent = user.content;
+        if (content_filter.value !== '') {
+          processedContent = user.content.replace(content_filter, '');
         }
-
-        //只有是评论列表的时候 才启用的过滤器
-        if (enable_comment_list.value) {
-
-
-            //用户等级过滤
-            if (result && min_level_filter.value !== '') {
-                result = user.level >= min_level_filter.value;
+        // 用户评论的日期必须等于预计算的该内容的最早日期
+        if (processedContent.length >=10){
+          let comment_time = parse_date_string_to_timestamp(user.date)
+          for (const other_comment_time in earliestDatesByContent[processedContent]) {
+            if (other_comment_time < comment_time && earliestDatesByContent[processedContent][other_comment_time].id !== user.id){
+              result = false;
             }
-
-            //VIP过滤
-            if (result && vip_filter.value === true) {
-                result = user.vip !== '';
-            }
-
-            //评论内容过滤
-            if (result && content_filter.value !== '') {
-                result = user.content.includes(content_filter.value);
-            }
-
-            //如果最早评论时间
-            if (result && date_comment_filter_start.value) {
-                result = parse_date_string(user.date) >= parse_date_string(date_comment_filter_start.value);
-            }
-
-            //如果最晚评论时间
-            if (result && date_comment_filter_end.value) {
-                result = parse_date_string(user.date) <= parse_date_string(date_comment_filter_end.value);
-            }
-
+          }
         }
+      }
+    }
+    return result;
+  });
+});
 
-        return result;
-
-    });
-
-})
+// 辅助函数示例 (你需要根据你的日期格式实现)
+// function parse_date_string(dateStr) {
+//     // 例如: return new Date(dateStr).getTime();
+//     // 或使用更健壮的日期解析库如 date-fns 或 moment.js
+//     // 确保能处理你项目中的日期格式
+//     return new Date(dateStr).getTime(); // 示例，返回时间戳以便比较
+// }
 
 
 
@@ -149,7 +195,7 @@ const display_filtered_list = computed(() => {
 
 watchEffect(() => {
 
-    //通过监听器, 在过滤列表产生变化的时候重置 offset分页    
+    //通过监听器, 在过滤列表产生变化的时候重置 offset分页
     list_offset.value = filtered_list.value ? 0 : 0;
 
 });
@@ -164,16 +210,13 @@ function calculate_array_result_list() {
         show_error_modal(true, '抽选人数无效')
         return
     }
-
     // 检查 抽选人数 是否小于或等于数组的长度
     if (number_people_selected_filter.value > filtered_list.value.length) {
         show_error_modal(true, '抽选人数必须小于或等于参加人数')
         return
     }
-
     //显示加载框
     show_loading_modal(true, '抽选中')
-
     //记录抽出的index
     const index_list = new Set();
 
@@ -195,7 +238,6 @@ function calculate_array_result_list() {
     //循环直到抽满所需人数
     // while (result_user_id_list.length < number_people_selected_filter.value)
     while (result_winner_list.length < number_people_selected_filter.value)
-
     //隐藏加载框
     show_loading_modal(false, '')
 
@@ -280,8 +322,9 @@ function reset_result_status() {
                         <span v-else>同用户多次转发/点赞</span> -->
                         </div>
                         <select class="form-select" v-model="repeat_comment_filter" :disabled="result_status">
-                            <option :value="false">不限制</option>
-                            <option :value="true">只保留一次</option>
+                          <option value="no_filter">不限制</option>
+                          <option value="last_user_comment">只保留同用户最后一次评论</option>
+                          <option value="earliest_long_identical">保留相同长评论的最早一次</option>
                         </select>
 
                         <template v-if="enable_comment_list">
@@ -331,7 +374,7 @@ function reset_result_status() {
                             <VueDatePicker v-model="date_comment_filter_end" auto-apply placeholder="不限制" locale="zh"
                                 format="yyyy-MM-dd HH:mm:ss" :disabled="result_status" />
                         </div>
-                       
+
                     </div>
 
 

--- a/vue/src/components/content/MyListContainer.vue
+++ b/vue/src/components/content/MyListContainer.vue
@@ -90,7 +90,8 @@ function make_comment_dict(){
         earliestDatesByContent[processedContent]={}
       }
       earliestDatesByContent[processedContent][userDateTimestamp] = user
-      }
+      user.relation_comment = earliestDatesByContent[processedContent]
+    }
 }
 
 const filtered_list = computed(() => {
@@ -160,7 +161,11 @@ const filtered_list = computed(() => {
           let comment_time = parse_date_string_to_timestamp(user.date)
           for (const other_comment_time in earliestDatesByContent[processedContent]) {
             if (other_comment_time < comment_time && earliestDatesByContent[processedContent][other_comment_time].id !== user.id){
+              user.relation_comment_is_slef = false
               result = false;
+            }
+            else {
+              user.relation_comment_is_slef = true
             }
           }
         }

--- a/vue/src/components/content/MyListContainer.vue
+++ b/vue/src/components/content/MyListContainer.vue
@@ -157,7 +157,7 @@ const filtered_list = computed(() => {
           processedContent = user.content.replace(content_filter, '');
         }
         // 用户评论的日期必须等于预计算的该内容的最早日期
-        if (processedContent.length >=10){
+        if (processedContent.length >=8){
           let comment_time = parse_date_string_to_timestamp(user.date)
           for (const other_comment_time in earliestDatesByContent[processedContent]) {
             if (other_comment_time < comment_time && earliestDatesByContent[processedContent][other_comment_time].id !== user.id){

--- a/vue/src/constants/injection-key.js
+++ b/vue/src/constants/injection-key.js
@@ -29,12 +29,11 @@ const INJECTION_KEY = {
     LIKE_LIST : 'like_list',
     FORWARD_LIST : 'forward_list',
     USER_LIST : 'user_list',
-    
 
     //判断什么时候展示列表
     SHOW_LIST : 'show_list',
 
-    
+
 
 }
 

--- a/vue/src/model/user-model.js
+++ b/vue/src/model/user-model.js
@@ -86,8 +86,9 @@ export class User_Model {
         this.relation_type_description = '';
         this.relation_date = '';
 
-
-
+        //相关评论
+        this.relation_comment = {}
+        this.relation_comment_is_slef = null
 
         //生成一个随机KEY, 用来避免vue重复渲染
         this.key = this.id + '' + get_random_int(1, 1000)

--- a/vue/src/utils/utils.js
+++ b/vue/src/utils/utils.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 /**
  * 判断是否为函数
- * @param {*} variable 
+ * @param {*} variable
  * @returns {boolean}
  */
 function is_function(variable) {
@@ -11,7 +11,7 @@ function is_function(variable) {
 
 /**
  * 判断对象是否为空
- * @param {object} obj 
+ * @param {object} obj
  * @returns {boolean}
  */
 function is_empty_object(obj) {
@@ -20,7 +20,7 @@ function is_empty_object(obj) {
 
 /**
  * 清空对象的所有属性
- * @param {object} obj 
+ * @param {object} obj
  * @returns {void}
  */
 function clear_object(obj) {
@@ -32,8 +32,8 @@ function clear_object(obj) {
 
 /**
  * 生成随机整数
- * @param {number} min 
- * @param {number} max 
+ * @param {number} min
+ * @param {number} max
  * @returns {number}
  */
 function get_random_int(min, max) {
@@ -42,8 +42,8 @@ function get_random_int(min, max) {
 
 /**
  * 解析日期时间字符串
- * @param {string} date_string 
- * @param {string} date_format 
+ * @param {string} date_string
+ * @param {string} date_format
  * @returns {Date|null}
  */
 function parse_date_string(date_string, date_format = 'YYYY-MM-DD HH:mm:ss') {
@@ -54,10 +54,15 @@ function parse_date_string(date_string, date_format = 'YYYY-MM-DD HH:mm:ss') {
 
     return result;
 }
-
+function parse_date_string_to_timestamp(date_string, date_format = 'YYYY-MM-DD HH:mm:ss') {
+    if (date_string) {
+        return moment(date_string, date_format).valueOf(); // 返回时间戳
+    }
+    return null;
+}
 /**
  * 解析时间对象 转换成字符串
- * @param {Date|null} date 
+ * @param {Date|null} date
  * @returns {string}
  */
 function format_date_to_string(date) {
@@ -79,4 +84,5 @@ export {
     get_random_int,
     parse_date_string,
     format_date_to_string,
+    parse_date_string_to_timestamp,
 }


### PR DESCRIPTION
-重构评论过滤逻辑，提高可扩展性和性能
- 添加"保留相同长评论的最早一次"过滤选项
- 优化用户界面，提供更清晰的过滤选项描述
- 修复了一些与日期过滤相关的潜在问题
- 在用户组件中增加关系评论相关字段和显示逻辑
- 在用户模型中添加关系评论相关属性
- 优化评论列表处理逻辑，增加对关系评论的判断和处理
效果展示：
![257c5802d30f29d5612e7b12e3881b3c](https://github.com/user-attachments/assets/f05f480e-a1ee-42bd-86f1-b1357f520f36)
![image](https://github.com/user-attachments/assets/2bd10e46-c920-460d-8c6b-0674be307dd8)
![image](https://github.com/user-attachments/assets/810f4098-e2c8-4077-9b38-5e47fc4e1bf0)
![image](https://github.com/user-attachments/assets/1b564f20-1392-4108-92b5-95c06f653805)


目的：避免二次举报造成时间浪费 提供开关供运营选择性开启
原因：大量运营抱怨开奖完举报抄袭 还要反复人工复查